### PR TITLE
start画面の人数を選ぶダイアログで、キャンセルボタンが押下されたら非表示になるようにしました

### DIFF
--- a/src/component/Start.jsx
+++ b/src/component/Start.jsx
@@ -1,17 +1,69 @@
-import React from "react";
+import React, { useState } from "react";
 import "../App.css";
-import { Button } from "@material-ui/core";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+} from "@material-ui/core";
 
 export default function Start() {
+  const [memberDialog, setMemberDialog] = useState(false);
+
   return (
-    <div className="title">
-      <h1>OFC検証アプリ</h1>
-      <Button className="start-left" variant="contained" color="primary">
-        54枚
-      </Button>
-      <Button className="start-right" variant="contained" color="primary">
-        52枚(ジョーカー抜き)
-      </Button>
-    </div>
+    <React.Fragment>
+      <div className="title">
+        <h1>OFC検証アプリ</h1>
+        <Button
+          className="start-left"
+          variant="contained"
+          color="primary"
+          onClick={() => {
+            setMemberDialog(true);
+          }}
+        >
+          54枚
+        </Button>
+        <Button
+          className="start-right"
+          variant="contained"
+          color="primary"
+          onClick={() => {
+            setMemberDialog(true);
+          }}
+        >
+          52枚(ジョーカー抜き)
+        </Button>
+        <Dialog open={memberDialog}>
+          <DialogContent>
+            <DialogContentText>何人でプレイしますか？</DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={() => {
+                setMemberDialog(true);
+              }}
+            >
+              2人
+            </Button>
+            <Button
+              onClick={() => {
+                setMemberDialog(true);
+              }}
+            >
+              3人
+            </Button>
+            <Button
+              onClick={() => {
+                setMemberDialog(false);
+              }}
+            >
+              キャンセル
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    </React.Fragment>
   );
 }


### PR DESCRIPTION
start画面の人数を選ぶダイアログで、キャンセルボタンが押下されたら非表示にする #9
が終了しました！

issueの#5と同時に実装したので同一の内容となります。
こちらもよろしくお願いいたします！