### PR TITLE
最終ゲームでのdeckを参照してSETボタンを非活性にしました。

### DIFF
--- a/src/component/Game.jsx
+++ b/src/component/Game.jsx
@@ -43,10 +43,6 @@ export default function Game() {
   const [preOppField2, setPreOppField2] = useState(oppField2);
 
   const history = useHistory();
-  let stopSetButton = document.getElementsByTagName("button").disabled;
-  if (deck.length <= 3) {
-    stopSetButton = true;
-  }
   function getRandomCard(count) {
     let result = [];
     let tmpDeck = deck.concat();
@@ -94,7 +90,7 @@ export default function Game() {
         <div className="btns_grave">
           <div className="btns">
             <Button
-              disabled={stopSetButton}
+              disabled={deck.length <= 11}
               id="setButton"
               variant="contained"
               color="primary"
@@ -107,7 +103,6 @@ export default function Game() {
                 setSelfField(randomCards.slice(0, 5));
                 setOppField1(randomCards.slice(5, 10));
                 setOppField2(randomCards.slice(10, 15));
-                console.log(deck.length);
               }}
             >
               SET
@@ -138,7 +133,6 @@ export default function Game() {
                     setSelfField(resetCards.slice(0, 5));
                     setOppField1(resetCards.slice(5, 10));
                     setOppField2(resetCards.slice(10, 15));
-                    console.log(deck.length);
                   }}
                 >
                   ランダム


### PR DESCRIPTION
お疲れ様です！

game画面内では、すべてのマスにカードが埋まったときは、SETボタンを非活性にする #18
こちらのissueが完了しましたのでpushさせていただきました。
—————————————
当初はクリック回数に応じてSETボタンを非活性にする想定でしたが、deckの最終的な枚数を参照して非活性にする形にしました。（まずは3人、ジョーカーありでの最終ゲームでのdeck枚数を参照し非活性に）

ジョーカーの有無や相手の人数に応じて最終ゲームでのdeckの枚数が変わるため、今後Redux化をする際に、else ifを必要に応じて増やす形とし、SETボタンの活性と非活性を管理しようと考えております。
—————————————
以上でございます！
ご確認お願いいたします。